### PR TITLE
Add UVerb instance for 0.18.1

### DIFF
--- a/hedgehog-servant.cabal
+++ b/hedgehog-servant.cabal
@@ -63,9 +63,9 @@ library
     , http-client               >= 0.5.14   && < 0.7
     , http-media                >= 0.8      && < 0.9
     , http-types                >= 0.12     && < 0.13
-    , servant                   >= 0.16     && < 0.18
-    , servant-client            >= 0.16     && < 0.18
-    , servant-server            >= 0.16     && < 0.18
+    , servant                   >= 0.16     && < 0.19
+    , servant-client            >= 0.16     && < 0.19
+    , servant-server            >= 0.16     && < 0.19
     , string-conversions        >= 0.4      && < 0.5
     , text                      >= 1.2      && < 1.3
 
@@ -123,8 +123,8 @@ test-suite hedgehog-servant-tests
     , http-client               >= 0.5.14   && < 0.7
     , http-media                >= 0.8      && < 0.9
     , http-types                >= 0.12     && < 0.13
-    , servant                   >= 0.16     && < 0.18
-    , servant-client            >= 0.16     && < 0.18
-    , servant-server            >= 0.16     && < 0.18
+    , servant                   >= 0.16     && < 0.19
+    , servant-client            >= 0.16     && < 0.19
+    , servant-server            >= 0.16     && < 0.19
     , string-conversions        >= 0.4      && < 0.5
     , text                      >= 1.2      && < 1.3

--- a/src/Hedgehog/Servant.hs
+++ b/src/Hedgehog/Servant.hs
@@ -36,6 +36,10 @@ import           Servant.Client (BaseUrl(..), Scheme(..))
 import           Servant.API (NoContentVerb)
 #endif
 
+#if MIN_VERSION_servant(0, 18, 1)
+import           Servant.API (UVerb)
+#endif
+
 -- | Data structure used in order to specify generators for API
 --
 -- Example usage:
@@ -253,6 +257,19 @@ instance
 instance
   ( ReflectMethod method
   ) => GenRequest (NoContentVerb method) gens where
+    genRequest _ _ =
+      pure $ \baseUrl -> defaultRequest
+        { host = cs . baseUrlHost $ baseUrl
+        , port = baseUrlPort baseUrl
+        , secure = baseUrlScheme baseUrl == Https
+        , method = reflectMethod (Proxy @method)
+        }
+#endif
+
+#if MIN_VERSION_servant(0, 18, 1)
+instance
+  ( ReflectMethod method
+  ) => GenRequest (UVerb method contentTypes bodies) gens where
     genRequest _ _ =
       pure $ \baseUrl -> defaultRequest
         { host = cs . baseUrlHost $ baseUrl


### PR DESCRIPTION
Hey, our project will soon start using the shiny new `UVerb` type from `servant` 0.18.1+, so we'll need `hedgehog-servant` to support it. I looked at the internals and it seems that the `GenRequest` instance should be pretty much identical to the ones for `Verb` and `NoContentVerb`, since for these we only need to return the base request without any `Gen` side effects, so that's what I added here.

Thanks!